### PR TITLE
Use instructions from bash hackers wiki to relay arguments

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -3,9 +3,6 @@
 each_command() {
   local plugin_name=$1
   shift
-  local each_args=("$@")
-
-  local each_cmd="${each_args[*]}"
 
   check_if_plugin_exists "$plugin_name"
 
@@ -26,7 +23,7 @@ each_command() {
       #   export ASDF_RUBY_VERSION=3.0.3
       #   asdf exec gem update --system
       export $version_env_var="$version"
-      asdf exec $each_cmd
+      asdf exec "$@"
     done
   else
     display_error '  No versions installed'


### PR DESCRIPTION
  * Fixes #1
  * Use quoted args pass from [the bash hackers wiki](https://wiki.bash-hackers.org/scripting/posparams#mass_usage)

For testing I used locally:

```sh
asdf each ruby ruby -e '"hello".gsub(/ll/) { |m| puts $` + m + $'"'"'; m }'
```

Unfortunately `plugin test` doesn't work with PR branches:

```sh
$ asdf plugin test each https://github.com/lonelyelk/asdf-each/tree/fix-quoted-params ruby ruby -e '"hello".sub /ll/ { |m| puts $` + m + $'"'"'; m }'
fatal: repository 'https://github.com/lonelyelk/asdf-each/tree/fix-quoted-params/' not found
FAILED: could not install each from https://github.com/lonelyelk/asdf-each/tree/fix-quoted-params
```

But I did it locally with:

```sh
asdf plugin remove each
asdf plugin add each .
asdf each ruby ruby -e '"hello".gsub(/ll/) { |m| puts $` + m + $'"'"'; m }'
```

The changes need to be committed to a local branch for this to works, since it uses git to install.